### PR TITLE
Handle new scope name for C++

### DIFF
--- a/grammars/objdump c++.cson
+++ b/grammars/objdump c++.cson
@@ -51,6 +51,11 @@
     'include': 'source.c'
   }
   {
+    'include': 'source.cpp'
+  }
+  
+  # For compatibility with Atom versions < 0.166
+  {
     'include': 'source.c++'
   }
 ]


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope names for C++ and Objective-C++ will change from `source.c++` and `source.objc++` to `source.cpp` and `source.objcpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Thanks!

Refs atom/language-c#54.
