### PR TITLE
Add comments for x86 (semicolons, i.e., ";" via command /)

### DIFF
--- a/settings/language-x86.cson
+++ b/settings/language-x86.cson
@@ -1,0 +1,3 @@
+'.source.x86asm':
+  'editor':
+    'commentStart': '; '


### PR DESCRIPTION
I have been writing MASM for a CS course and being able to comment out code with **command /** in Atom has been very useful.

This is my first pull request ever. :+1: 
